### PR TITLE
Add base theme from hm-base

### DIFF
--- a/content/themes/base/footer.php
+++ b/content/themes/base/footer.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * The template for displaying the page footer.
+ *
+ * This file is yours to edit and replace.
+ */
+?>
+
+<?php wp_footer(); ?>
+
+</body>
+</html>

--- a/content/themes/base/functions.php
+++ b/content/themes/base/functions.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Entrypoint for theme functionality.
+ *
+ * This file is yours to edit and replace.
+ */
+
+namespace YourProject;
+
+require __DIR__. '/inc/namespace.php';
+
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets' );

--- a/content/themes/base/header.php
+++ b/content/themes/base/header.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * The template for displaying the page header.
+ *
+ * This file is yours to edit and replace.
+ */
+?>
+<!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<?php wp_head(); ?>
+</head>
+
+<body <?php body_class(); ?>>

--- a/content/themes/base/inc/namespace.php
+++ b/content/themes/base/inc/namespace.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Entrypoint for theme functionality.
+ */
+
+namespace YourProject;
+
+const SLUG = 'yourproject';
+
+/**
+ * Enqueue static assets.
+ *
+ * Adds the default stylesheet to the repo.
+ */
+function enqueue_assets() {
+	wp_enqueue_style( SLUG, get_stylesheet_uri() );
+}

--- a/content/themes/base/index.php
+++ b/content/themes/base/index.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * The default template file.
+ *
+ * This file is yours to edit and replace.
+ */
+
+get_header();
+
+?>
+	<div id="welcome">
+		<h1><?php esc_html_e( 'Welcome to HM Platform', 'hm-platform' ) ?></h1>
+		<p><?php _e( 'HM Platform is installed and ready to go. To get started, edit this placeholder theme at<br><code>content/themes/base</code>', 'hm-platform' ) ?></p>
+		<p><a href="<?php echo admin_url( 'admin.php?page=hm-platform' ) ?>"><?php esc_html_e( 'View HM Platform documentation', 'hm-platform' ) ?></a></p>
+	</div>
+<?php
+
+get_footer();

--- a/content/themes/base/style.css
+++ b/content/themes/base/style.css
@@ -1,0 +1,25 @@
+/*
+Theme Name: Base Theme
+Author: You
+
+This file is yours to edit and replace.
+*/
+
+:root {
+	--color-blue: #4667de;
+	--color-darkblue: #152a4e;
+	--color-green: #3fcf8e;
+	--color-offwhite: #f3f5f9;
+}
+
+body {
+	background: #f1f1f1;
+	font: 16px/1.6 sans-serif;
+}
+
+#welcome {
+	background: #fff;
+	width: 60%;
+	padding: 1rem;
+	margin: 1rem auto;
+}


### PR DESCRIPTION
Adds a base theme derived from the one in [hm-base](https://github.com/humanmade/hm-base/tree/master/content/themes/hm-base-theme).

There's too much code in here, but IMO that's OK for now. When we style `wp_die`, we can use that callback and styling here instead as well.