### PR TITLE
Bump to v1 beta 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
             "email": "hello@humanmade.com"
         }
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "beta",
     "extra": {
         "installer-paths": {
             "content/plugins/{$name}/": [

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "A base HM Platform project to get started with",
     "type": "project",
     "require": {
-        "humanmade/platform": "dev-master"
+        "humanmade/platform": "1.0.0-beta1"
     },
     "require-dev": {
-        "humanmade/platform-local-chassis": "dev-master",
-        "humanmade/local-server": "dev-master"
+        "humanmade/platform-local-chassis": "1.0.0-beta1",
+        "humanmade/local-server": "1.0.0-beta1"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     "minimum-stability": "beta",
     "extra": {
         "installer-paths": {
+            "content/mu-plugins/{$name}/": [
+                "type:wordpress-muplugin"
+            ],
             "content/plugins/{$name}/": [
                 "type:wordpress-plugin"
             ],


### PR DESCRIPTION
Require 1.0 beta 1 for everything. Also adds the missing mu-plugins config.